### PR TITLE
Uncaught Exception: cannot open, Fix

### DIFF
--- a/Base.php
+++ b/Base.php
@@ -50,7 +50,11 @@ abstract class Base
         if (isset($options['trustHtml'])) {
             $this->trustHtml = ($options['trustHtml'] == true);
         }
-
+        
+        if(!file_exists($this->tmpPath)){
+            mkdir($this->tmpPath);
+        }
+        
         $this->tmpZipFile = $this->tmpPath . uniqid('zip-');
         file_put_contents($this->tmpZipFile, $template);
 


### PR DESCRIPTION
This little edit allows to fix this error:
Warning: file_put_contents(/tmp/zip-5a661c3d6fc4d): failed to open stream: No such file or directory in D:\<A>\<B>\html2doc\vendor\catoth\html2opendocument\Base.php on line 55

Fatal error: Uncaught Exception: cannot open </tmp/zip-5a661c3d6fc4d> in D:\<A>\<B>\html2doc\vendor\catoth\html2opendocument\Base.php:59 Stack trace: #0 D:\<A>\<B>\html2doc\vendor\catoth\html2opendocument\Text.php(40): CatoTH\HTML2OpenDocument\Base->__construct('D:\\<A>\\<B>...', Array) #1 D:\<A>\<B>\html2doc\index.php(23): CatoTH\HTML2OpenDocument\Text->__construct() #2 {main} thrown in D:\<A>\<B>\html2doc\vendor\catoth\html2opendocument\Base.php on line 59